### PR TITLE
Replace documentation tables in README with type signatures and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ npm install ternary-search-trie
 yarn add ternary-search-trie
 ```
 
-End with an example of getting some data out of the system or using it for a little demo
-
 ## Documentation
 
 ## Trie
@@ -40,77 +38,196 @@ const trie = new Trie<Value>();
 
 ### Members
 
-#### Trie.size
+- [isEmpty](#isEmpty)
+- [size](#size)
 
-Gets the size of the tree in terms of the number of nodes present within the tree.
-
-#### Trie.isEmpty
+#### isEmpty
 
 Returns true if the tree contains any nodes, otherwise false.
 
+```typescript
+console.log(trie.isEmpty);
+//=> true
+```
+
+#### size
+
+Gets the size of the tree in terms of the number of nodes present within the tree.
+
+```typescript
+console.log(trie.size);
+//=> 0
+```
+
 ### Methods
 
-#### set(key, value)
+- [set](#set)
+- [get](#get)
+- [del](#del)
+- [contains](#contains)
+- [keys](#keys)
+- [keysWithPrefix](#keysWithPrefix)
+- [searchWithPrefix](#searchWithPrefix)
+- [dfs](#dfs)
+
+#### set
+
+```typescript
+set(key: string, value: Value): Trie<Value>
+```
 
 Adds the specified key/value pair to the tree.
 
-| Param |  Type  | Description          |
-| ----- | :----: | :------------------- |
-| key   | string | The key to add       |
-| value | Value  | The value of the key |
+Example:
 
-#### get(key)
+```typescript
+const value = { data: 'test' };
+
+trie.set('data', value);
+```
+
+#### get
+
+```typescript
+get(key: string): Value | null
+```
 
 Returns the value of the node with the specified key.
 
-| Param |  Type  | Description         |
-| ----- | :----: | :------------------ |
-| key   | string | The key of the node |
+Example:
 
-#### del(key)
+```typescript
+const value = { data: 'test' };
+
+trie.set('data', value);
+
+console.log(trie.get('data'));
+//=> { data: 'test' }
+```
+
+#### del
+
+```typescript
+del(key: string): Trie<Value>
+```
 
 Deletes the node with the specified key.
 
-| Param |  Type  | Description                   |
-| ----- | :----: | :---------------------------- |
-| key   | string | The key of the node to delete |
+Example:
 
-#### contains(key)
+```typescript
+const value = { data: 'test' };
+
+trie.set('data', value);
+
+console.log(trie.get('data'));
+//=> { data: 'test' }
+
+trie.del('data');
+
+console.log(trie.get('data'));
+//=> null;
+```
+
+#### contains
+
+```typescript
+contains(key: string): boolean
+```
 
 Checks if a node with the specified key exists in the tree.
 
-| Param |  Type  | Description                  |
-| ----- | :----: | :--------------------------- |
-| key   | string | The key of the node to check |
+Example:
 
-#### dfs(callback)
+```typescript
+console.log(trie.contains('foo'));
+//=> false
+```
 
-Performs a depth-first search of the tree beginning from the root node. Executes the specified callback at each visited node.
+#### keys
 
-| Param    |              Type               | Description             |
-| -------- | :-----------------------------: | :---------------------- |
-| callback | (node: Node<ValueType>) => void | The callback to execute |
-
-#### keys()
+```typescript
+keys(): string[]
+```
 
 Returns an array of all keys present in the tree.
 
-#### keysWithPrefix(prefix)
+Example:
+
+```typescript
+const value = { data: 'test' };
+
+trie.set('foo', value);
+trie.set('bar', value);
+trie.set('baz', value);
+
+console.log(trie.keys());
+//=>  [ 'bar', 'baz', 'foo' ]
+```
+
+#### keysWithPrefix
+
+```typescript
+keysWithPrefix(prefix: string): string[]
+```
 
 Returns all keys present in the tree that begin with the specified prefix.
 
-| Param  |  Type  | Description             |
-| ------ | :----: | :---------------------- |
-| prefix | string | The prefix to search by |
+Example:
 
-#### searchWithPrefix(prefix, callback)
+```typescript
+const value = { data: 'test' };
+
+trie.set('foo', value);
+trie.set('bar', value);
+trie.set('baz', value);
+
+console.log(trie.keysWithPrefix('ba'));
+//=>  [ 'bar', 'baz' ]
+```
+
+#### searchWithPrefix
+
+```typescript
+searchWithPrefix(prefix: string, callback: (key: string, value: Value | null) => void): void;
+```
 
 Executes the specified callback at each node in the tree whose key begins with the specified prefix.
 
-| Param    |                       Type                        | Description             |
-| -------- | :-----------------------------------------------: | :---------------------- |
-| prefix   |                      string                       | The prefix to search by |
-| callback | (prefix: string, (node: Node<ValueType>) => void) | The callback to execute |
+Example:
+
+```typescript
+const value = { data: 'test' };
+
+trie.set('foo', value);
+trie.set('bar', value);
+trie.set('baz', value);
+
+trie.searchWithPrefix('ba', node => console.log({ key: node.key, value: node.value }));
+//=> { key: 'bar', value: { data: 'test' } }
+//=> { key: 'baz', value: { data: 'test' } }
+```
+
+#### dfs
+
+```typescript
+dfs(callback: (key: string, value: Value | null) => void): void;
+```
+
+Performs a depth-first search of the tree beginning from the root node. Executes the specified callback at each visited node.
+
+Example:
+
+```typescript
+const value = { data: 'test' };
+
+trie.set('foo', value);
+
+trie.dfs((key, value) => console.log({ key, value }));
+//=> { key: 'f', value: null }
+//=> { key: 'o', value: null }
+//=> { key: 'o', value: { data: 'test' } }
+```
 
 #### toString()
 


### PR DESCRIPTION
This PR adds type signatures and examples to the README for each method exposed by the `Trie`. Removes the previous method of documenting methods in a tabular format. Effectively closes #1. 